### PR TITLE
Add statistics endpoint and utilities to API

### DIFF
--- a/app/Helper/helper_fcts.php
+++ b/app/Helper/helper_fcts.php
@@ -22,3 +22,21 @@ if (!function_exists('getColumnName')) {
 		return $result;
 	}
 }
+
+if (!function_exists('castToNumericIfPossible')) {
+	/**
+	 * Casts a string to an integer or float if it is numeric.
+	 *
+	 * @param  string|null  $value  The input string.
+	 * @return int|float|string|null The casted value or the original value.
+	 */
+	function castToNumericIfPossible(string|null $value): int|float|string|null
+	{
+		if (is_null($value) || !is_numeric($value)) {
+			return $value;
+		}
+
+		// Cast to float if it contains a decimal point, otherwise to int.
+		return str_contains($value, '.') ? (float) $value : (int) $value;
+	}
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -10,40 +10,67 @@ use Symfony\Component\HttpFoundation\Response as Response;
 
 class ApiController extends Controller
 {
-	private GoogleApiService $apiService;
+    private GoogleApiService $apiService;
 
-	public function __construct()
-	{
-		$this->apiService = new GoogleApiService();
-	}
+    public function __construct()
+    {
+        $this->apiService = new GoogleApiService();
+    }
 
-	public function receiveResults(ChallengeDataRequest $request): JsonResponse
-	{
-		/**
-		 * if data already exist, update it
-		 */
-		if ($this->apiService->dataExists($request)) {
-			try {
-				$this->apiService->updateData($request);
-			} catch (GoogleSheetException) {
-				return response()->json([
-					'message' => sprintf('Sorry %s, you never should see this error 🫣', $request->getName()),
-				], Response::HTTP_BAD_REQUEST);
-			}
+    public function receiveResults(ChallengeDataRequest $request): JsonResponse
+    {
+        /**
+         * if data already exist, update it
+         */
+        if ($this->apiService->dataExists($request)) {
+            try {
+                $this->apiService->updateData($request);
+            } catch (GoogleSheetException) {
+                return response()->json([
+                    'message' => sprintf('Sorry %s, you never should see this error 🫣', $request->getName()),
+                ], Response::HTTP_BAD_REQUEST);
+            }
 
-			return response()->json([
-				'message' => sprintf('Hey %s, deine Infos für den %s wurden aktualisiert!', $request->getName(),
-					$request->getDate()),
-			], Response::HTTP_OK, ['Content-Type' => 'application/json;charset=UTF-8', 'Charset' => 'utf-8'],
-				JSON_UNESCAPED_UNICODE);
-		}
-		// create new dataset
-		$this->apiService->appendData($request);
+            return response()->json([
+                'message' => sprintf('Hey %s, deine Infos für den %s wurden aktualisiert!', $request->getName(),
+                    $request->getDate()),
+            ], Response::HTTP_OK, ['Content-Type' => 'application/json;charset=UTF-8', 'Charset' => 'utf-8'],
+                JSON_UNESCAPED_UNICODE);
+        }
+        // create new dataset
+        $this->apiService->appendData($request);
 
-		return response()->json([
-			'message' => sprintf('Hey %s, Tagesupdate für den %s wurde übertragen!', $request->getName(),
-				$request->getDate()),
-		], Response::HTTP_OK, ['Content-Type' => 'application/json;charset=UTF-8', 'Charset' => 'utf-8'],
-			JSON_UNESCAPED_UNICODE);
-	}
+        return response()->json([
+            'message' => sprintf('Hey %s, Tagesupdate für den %s wurde übertragen!', $request->getName(),
+                $request->getDate()),
+        ], Response::HTTP_OK, ['Content-Type' => 'application/json;charset=UTF-8', 'Charset' => 'utf-8'],
+            JSON_UNESCAPED_UNICODE);
+    }
+
+    public function getStatistics(): JsonResponse
+    {
+        $statisticRanges = [
+            'current_day' => 'Overview!R3',
+        ];
+
+        $data = [];
+        $errors = [];
+
+        foreach ($statisticRanges as $key => $range) {
+            $value = $this->apiService->getValueFromCell($range);
+
+            if (is_null($value)) {
+                $errors[] = sprintf('Could not read the value %s of the cell %s', $key, $range);
+            } else {
+                // Cast to a numeric type if possible using the helper
+                $data[$key] = castToNumericIfPossible($value);
+            }
+        }
+
+        if (!empty($errors)) {
+            return response()->json(['errors' => $errors], Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json(['data' => $data]);
+    }
 }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -71,6 +71,6 @@ class ApiController extends Controller
             return response()->json(['errors' => $errors], Response::HTTP_NOT_FOUND);
         }
 
-        return response()->json(['data' => $data]);
+        return response()->json(['statistic_data' => $data]);
     }
 }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -68,7 +68,7 @@ class ApiController extends Controller
         }
 
         if (!empty($errors)) {
-            return response()->json(['errors' => $errors], Response::HTTP_NOT_FOUND);
+            return response()->json(['errors' => $errors], Response::HTTP_SERVICE_UNAVAILABLE);
         }
 
         return response()->json(['data' => $data]);

--- a/app/Http/Service/GoogleApiService.php
+++ b/app/Http/Service/GoogleApiService.php
@@ -5,6 +5,7 @@ namespace App\Http\Service;
 use App\Exceptions\GoogleSheetException;
 use App\Http\Requests\ChallengeDataRequest;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 use Revolution\Google\Sheets\Facades\Sheets;
 
 class GoogleApiService
@@ -58,5 +59,25 @@ class GoogleApiService
 		Sheets::spreadsheet(config('challenge.sheet_id'))
 			->sheet(config('challenge.sheet_name'))
 			->append([$data->transformRequestToArray()], 'USER_ENTERED');
+	}
+
+    /**
+     * Retrieves the value from a specified cell range in the spreadsheet.
+     *
+     * @param  string  $range  The cell range to retrieve the value from.
+     *
+     * @return string|null The value of the cell, or null if no value is found or an exception occurs.
+     */
+	public function getValueFromCell(string $range): ?string
+	{
+		try {
+			$values = Sheets::spreadsheet(config('challenge.sheet_id'))
+				->range($range)
+				->get();
+			return $values->first()[0] ?? null;
+		} catch (\Exception $e) {
+			Log::error('Google Sheets API error in getValueFromCell: '.$e->getMessage());
+			return null;
+		}
 	}
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,3 +15,4 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('challenge_results', [ApiController::class, 'receiveResults']);
+Route::get('statistics', [ApiController::class, 'getStatistics']);


### PR DESCRIPTION
### Description

This pull request introduces a new `statistics` endpoint to the API by adding the necessary route and supporting methods. Key changes include:

- Added `getStatistics` method in `ApiController` for handling statistics logic.
- Improved code alignment for better readability and maintainability.
- Introduced `castToNumericIfPossible` helper function to convert strings to numeric values where applicable.
- Implemented `getValueFromCell` method in `GoogleApiService` for fetching individual cell values. 
- Added a `statistics` route to the API to expose the new functionality.

These changes aim to enhance functionality and ensure code clarity.